### PR TITLE
object名をリネーム

### DIFF
--- a/src/main/scala/Server.scala
+++ b/src/main/scala/Server.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 
 
-object server {
+object Server {
   def main(args: Array[String]) {
     implicit val actorSystem = ActorSystem("hello-system")
     implicit val actorMaterializer = ActorMaterializer()


### PR DESCRIPTION
シングルトンオブジェクトはキャメルケースでかいておいたほうがよかったはず。
